### PR TITLE
Card removal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,29 +4,28 @@ import logo from "../public/FischLogo.svg";
 
 import styles from "./App.module.css";
 import { Card } from "./components/Card";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 function App() {
+  const [cardsAmount, setCardsAmount] = useState(1)
   const [cards, setCards] = useState([{}]);
 
   const handleAddCardButtonClick = () => {
+    setCardsAmount(cardsAmount+1)
     setCards(prevCards => [...prevCards, {}]);
   };
-
-  const handleDeleteCardButtonClick = (index:number) => {
-    //to be implemented
-  };
+  
 
   const renderCards = () => {
-    return cards.map((card, index) => (
-      <Card key={index} onDelete={() => handleDeleteCardButtonClick(index)} />
+    return cards.map(() => (
+      <Card cardsAmount={cardsAmount} setCardsAmount={setCardsAmount} />
     ));
   };
 
   return (
     <AppLayout>
       <AppHeader
-        cardAmount={cards.length}
+        cardsAmount={cardsAmount}
         logoURL={logo}
         onClick={handleAddCardButtonClick}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import logo from "../public/FischLogo.svg";
 
 import styles from "./App.module.css";
 import { Card } from "./components/Card";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 function App() {
   const [cardsAmount, setCardsAmount] = useState(1)
@@ -15,7 +15,6 @@ function App() {
     setCards(prevCards => [...prevCards, {}]);
   };
   
-
   const renderCards = () => {
     return cards.map(() => (
       <Card cardsAmount={cardsAmount} setCardsAmount={setCardsAmount} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,31 +4,38 @@ import logo from "../public/FischLogo.svg";
 
 import styles from "./App.module.css";
 import { Card } from "./components/Card";
-import { useState } from "react";
+import { JSX, JSXElementConstructor, useState } from "react";
+import { NewCard } from "./components/NewCard";
 
 function App() {
-  const [cardsAmount, setCardsAmount] = useState(1)
-  const [cardsFrameArray, setcardsFrameArray] = useState([{}]);
+
+  let cardsMemory = [{front: "FRONT", back: "BACK"}]
+
+  let basicCards: JSX.Element[] = []
+
+  cardsMemory.forEach(cardValues => {
+    basicCards.push(<Card faceValue={cardValues.front} flipValue={cardValues.back}/>)
+  })
+
+  const [cardsArray, setCardsArray] = useState(basicCards)
 
   const handleAddCardButtonClick = () => {
-    setCardsAmount(cardsAmount+1)
-    setcardsFrameArray(prevCards => [...prevCards, {}]);
+    setCardsArray([<NewCard />, ...cardsArray])
   };
+
   
-  const renderCards = () => {
-    return cardsFrameArray.map(() => (
-      <Card cardsAmount={cardsAmount} setCardsAmount={setCardsAmount} />
-    ));
-  };
+
 
   return (
     <AppLayout>
       <AppHeader
-        cardsAmount={cardsAmount}
+        cardsAmount={cardsArray.length}
         logoURL={logo}
         onClick={handleAddCardButtonClick}
       />
-      <div className={styles.renderContainer}>{renderCards()}</div>
+      <div className={styles.renderContainer}>
+        {cardsArray}
+      </div>
     </AppLayout>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,15 @@ import { useState } from "react";
 
 function App() {
   const [cardsAmount, setCardsAmount] = useState(1)
-  const [cards, setCards] = useState([{}]);
+  const [cardsFrameArray, setcardsFrameArray] = useState([{}]);
 
   const handleAddCardButtonClick = () => {
     setCardsAmount(cardsAmount+1)
-    setCards(prevCards => [...prevCards, {}]);
+    setcardsFrameArray(prevCards => [...prevCards, {}]);
   };
   
   const renderCards = () => {
-    return cards.map(() => (
+    return cardsFrameArray.map(() => (
       <Card cardsAmount={cardsAmount} setCardsAmount={setCardsAmount} />
     ));
   };

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,14 +1,13 @@
-import React, { MutableRefObject, useRef, useState } from "react";
+import React from "react";
 import styles from "./AppHeader.module.css";
 import { NewCardButton } from "./AddNewCardButton";
 interface HeaderProps {
   cardsAmount: number;
   logoURL: string;
-  onClick: ()=>void;
+  onClick: () => void;
 }
 
 export const AppHeader = (props: HeaderProps) => {
-
   return (
     <header className={styles.header}>
       <img className={styles.logo} src={props.logoURL} alt="FischkApp logo" />
@@ -17,7 +16,9 @@ export const AppHeader = (props: HeaderProps) => {
           Cards: <>{props.cardsAmount}</>
         </span>
       </div>
-      <div className={styles.buttonWrap}><NewCardButton onClick={props.onClick} /></div>
+      <div className={styles.buttonWrap}>
+        <NewCardButton onClick={props.onClick} />
+      </div>
     </header>
   );
 };

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,19 +1,20 @@
-import React from "react";
+import React, { MutableRefObject, useRef, useState } from "react";
 import styles from "./AppHeader.module.css";
 import { NewCardButton } from "./AddNewCardButton";
 interface HeaderProps {
-  cardAmount: Number;
+  cardsAmount: number;
   logoURL: string;
   onClick: ()=>void;
 }
 
 export const AppHeader = (props: HeaderProps) => {
+
   return (
     <header className={styles.header}>
       <img className={styles.logo} src={props.logoURL} alt="FischkApp logo" />
       <div className={styles.textWrap}>
         <span className={styles.text}>
-          Cards: <>{props.cardAmount}</>
+          Cards: <>{props.cardsAmount}</>
         </span>
       </div>
       <div className={styles.buttonWrap}><NewCardButton onClick={props.onClick} /></div>

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -31,6 +31,8 @@
 }
 
 .caption {
+  position: absolute;
+  margin-top: 28px;
   margin-left: 15px;
   align-self: start;
   font-family: Lexend;

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -14,6 +14,7 @@
   overflow: auto;
 }
 
+
 .basicText {
   font: Lexend;
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
 import styles from "./Card.module.css";
 import { TextInput } from "./TextInput";
 import { SmallIconButton } from "./SmallIconButton";
@@ -6,8 +12,8 @@ import { TextOutput } from "./TextOutput";
 import { BigButton } from "./BigButton";
 
 interface CardProps {
-  onDelete: ()=>void;
-  key: number
+  cardsAmount: number;
+  setCardsAmount: Dispatch<SetStateAction<number>>;
 }
 
 export const Card = (props: CardProps) => {
@@ -18,7 +24,7 @@ export const Card = (props: CardProps) => {
   const [flipValue, setFlipValue] = useState("");
 
   //wether we're editing the card
-  const [editEnabled, setEditEnabled] = useState(false);
+  const [editEnabled, setEditEnabled] = useState(true);
 
   //flipState on = side A displayed, flipState off = side B
   const [flipState, setFlipState] = useState(true);
@@ -28,10 +34,13 @@ export const Card = (props: CardProps) => {
   const [inputDisplayValue, setInputDisplayValue] = useState(
     flipState ? faceValue : flipValue
   );
+
   useEffect(() => {
     setInputDisplayValue(flipState ? tempFaceValue : flipValue);
   }, [flipState, faceValue, flipValue, tempFaceValue]);
 
+  //state and custom event for handling card removal
+  const [removeStatus, setRemoveStatus] = useState(false);
 
   function handleTap() {
     setFlipState(!flipState);
@@ -43,48 +52,65 @@ export const Card = (props: CardProps) => {
   }
 
   const handleCancelButtonClick = () => {
-    handleEditButtonClick();
+    if (faceValue === "") {
+      handleDeleteButtonClick();
+    } else {
+      handleEditButtonClick();
+    }
   };
 
   const handleNextButtonClick = () => {
-    setTempFaceValue(inputDisplayValue)
+    setTempFaceValue(inputDisplayValue);
     handleTap();
   };
-  const handleSaveButtonClick = (event: React.MouseEvent) => {
+  const handleSaveButtonClick = (event?: React.MouseEvent) => {
     setFaceValue(tempFaceValue);
     setFlipValue(inputDisplayValue);
     handleEditButtonClick();
-    event.stopPropagation();
+    if (event) event.stopPropagation();
   };
-  const handleBackButtonClick = (event: React.MouseEvent) => {
+  const handleBackButtonClick = (event?: React.MouseEvent) => {
     handleTap();
-    event.stopPropagation();
+    if (event) event.stopPropagation();
   };
-  const handleDeleteButtonClick = (event: React.MouseEvent) => {
-    props.onDelete();
-    event.stopPropagation();
+
+  const handleDeleteButtonClick = (event?: React.MouseEvent) => {
+    props.setCardsAmount(props.cardsAmount - 1);
+    setRemoveStatus(true);
+    if (event) event.stopPropagation();
   };
 
   const handleTextInputOnChange = function (event: React.ChangeEvent) {
     const target = event.target as HTMLTextAreaElement;
-    setInputDisplayValue(target.value)
+    setInputDisplayValue(target.value);
     target.style.height = "19px";
     target.style.height = `${target.scrollHeight}px`;
   };
 
+  if (removeStatus) return null;
+
   if (editEnabled) {
     return (
-      <div className={styles.card} onClick={() => {}} key={props.key}>
+      <div className={styles.card} onClick={() => {}}>
         <SmallIconButton
-          type={editEnabled ? "delete" : "edit"}
-          onClick={editEnabled ? handleDeleteButtonClick : handleEditButtonClick}
+          type={"delete"}
+          onClick={
+            editEnabled ? handleDeleteButtonClick : handleEditButtonClick
+          }
         />
-        {!flipState && <TextOutput className={styles.caption}>{tempFaceValue}</TextOutput>}
-        <TextInput value={inputDisplayValue} onChange={handleTextInputOnChange} />
+        {!flipState && (
+          <TextOutput className={styles.caption}>{tempFaceValue}</TextOutput>
+        )}
+        <TextInput
+          value={inputDisplayValue}
+          onChange={handleTextInputOnChange}
+        />
         <div className={styles.buttonWrapper}>
           <BigButton
             colorToggle={false}
-            onClick={flipState ? handleCancelButtonClick : handleBackButtonClick}
+            onClick={
+              flipState ? handleCancelButtonClick : handleBackButtonClick
+            }
           >
             {flipState ? "Cancel" : "Back"}
           </BigButton>
@@ -100,13 +126,11 @@ export const Card = (props: CardProps) => {
   } else {
     return (
       <div className={styles.card} onClick={handleTap}>
-        <SmallIconButton
-          type={editEnabled ? "delete" : "edit"}
-          onClick={handleEditButtonClick}
-        />
+        <SmallIconButton type={"edit"} onClick={handleEditButtonClick} />
         <TextOutput>{flipState ? faceValue : flipValue}</TextOutput>
-        {/**this second, empty textoutput exists only so that i can simply use 
-         * a single "justify-content: space-between;" on it's wrapper div*/}
+        {/**this second, empty textoutput exists only so that i can simply use
+         * a single "justify-content: space-between;" on it's wrapper div
+         * to make it look exactly like the project requirements! :D*/}
         <TextOutput></TextOutput>
       </div>
     );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,19 +6,26 @@ import { TextOutput } from "./TextOutput";
 import { BigButton } from "./BigButton";
 
 interface CardProps {
+  /**side A of the card*/
+  faceValue?: string;
+  /**side B of the card*/
+  flipValue?: string;
   cardsAmount: number;
   setCardsAmount: Dispatch<SetStateAction<number>>;
 }
 
 export const Card = (props: CardProps) => {
   // text on side A
-  const [faceValue, setFaceValue] = useState("");
-  const [tempFaceValue, setTempFaceValue] = useState(faceValue);
+  const [faceValue, setFaceValue] = useState(
+    props.faceValue ? props.faceValue : ""
+  );
   // text on side B
-  const [flipValue, setFlipValue] = useState("");
+  const [flipValue, setFlipValue] = useState(
+    props.flipValue ? props.flipValue : ""
+  );
 
   //wether we're editing the card
-  const [editEnabled, setEditEnabled] = useState(true);
+  const [editEnabled, setEditEnabled] = useState(false);
 
   //flipState on = side A displayed, flipState off = side B
   const [flipState, setFlipState] = useState(true);
@@ -30,8 +37,11 @@ export const Card = (props: CardProps) => {
   );
 
   useEffect(() => {
-    setInputDisplayValue(flipState ? tempFaceValue : flipValue);
-  }, [flipState, faceValue, flipValue, tempFaceValue]);
+    setInputDisplayValue(flipState ? faceValue : flipValue);
+  }, [flipState, faceValue, flipValue]);
+
+  //state used for changing the height of the text display
+  const [textOutputHeight, setTextOutputHeight] = useState(19);
 
   //state and custom event for handling card removal
   const [removeStatus, setRemoveStatus] = useState(false);
@@ -46,25 +56,16 @@ export const Card = (props: CardProps) => {
   }
 
   const handleCancelButtonClick = () => {
-    if (faceValue === "" && flipValue === "") {
-      handleDeleteButtonClick();
-    } else {
-      handleEditButtonClick();
-    }
+    handleEditButtonClick();
   };
 
-  const handleNextButtonClick = () => {
-    setTempFaceValue(inputDisplayValue);
-    handleTap();
-  };
   const handleSaveButtonClick = (event?: React.MouseEvent) => {
-    setFaceValue(tempFaceValue);
-    setFlipValue(inputDisplayValue);
+    if (flipState) {
+      setFaceValue(inputDisplayValue);
+    } else {
+      setFlipValue(inputDisplayValue);
+    }
     handleEditButtonClick();
-    if (event) event.stopPropagation();
-  };
-  const handleBackButtonClick = (event?: React.MouseEvent) => {
-    handleTap();
     if (event) event.stopPropagation();
   };
 
@@ -76,9 +77,14 @@ export const Card = (props: CardProps) => {
 
   const handleTextInputOnChange = function (event: React.ChangeEvent) {
     const target = event.target as HTMLTextAreaElement;
+    const newHeight = target.scrollHeight;
     setInputDisplayValue(target.value);
-    target.style.height = "19px";
-    target.style.height = `${target.scrollHeight}px`;
+    target.style.height = `${
+      newHeight > textOutputHeight ? newHeight : textOutputHeight
+    }px`;
+    setTextOutputHeight(
+      newHeight > textOutputHeight ? newHeight : textOutputHeight
+    );
   };
 
   if (removeStatus) return null;
@@ -86,33 +92,18 @@ export const Card = (props: CardProps) => {
   if (editEnabled) {
     return (
       <div className={styles.card} onClick={() => {}}>
-        <SmallIconButton
-          type={"delete"}
-          onClick={
-            editEnabled ? handleDeleteButtonClick : handleEditButtonClick
-          }
-        />
-        {!flipState && (
-          <TextOutput className={styles.caption}>{tempFaceValue}</TextOutput>
-        )}
+        <SmallIconButton type={"delete"} onClick={handleDeleteButtonClick} />
         <TextInput
+          height={textOutputHeight}
           value={inputDisplayValue}
           onChange={handleTextInputOnChange}
         />
         <div className={styles.buttonWrapper}>
-          <BigButton
-            colorToggle={false}
-            onClick={
-              flipState ? handleCancelButtonClick : handleBackButtonClick
-            }
-          >
-            {flipState ? "Cancel" : "Back"}
+          <BigButton colorToggle={false} onClick={handleCancelButtonClick}>
+            Cancel
           </BigButton>
-          <BigButton
-            colorToggle={true}
-            onClick={flipState ? handleNextButtonClick : handleSaveButtonClick}
-          >
-            {flipState ? "Next" : "Save"}
+          <BigButton colorToggle={true} onClick={handleSaveButtonClick}>
+            Save
           </BigButton>
         </div>
       </div>
@@ -121,11 +112,13 @@ export const Card = (props: CardProps) => {
     return (
       <div className={styles.card} onClick={handleTap}>
         <SmallIconButton type={"edit"} onClick={handleEditButtonClick} />
-        <TextOutput>{flipState ? faceValue : flipValue}</TextOutput>
+        <TextOutput height={textOutputHeight}>
+          {flipState ? faceValue : flipValue}
+        </TextOutput>
         {/**this second, empty textoutput exists only so that i can simply use
          * a single "justify-content: space-between;" on it's wrapper div
          * to make it look exactly like the project requirements! :D*/}
-        <TextOutput></TextOutput>
+        <TextOutput height={19}></TextOutput>
       </div>
     );
   }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -105,6 +105,9 @@ export const Card = (props: CardProps) => {
           onClick={handleEditButtonClick}
         />
         <TextOutput>{flipState ? faceValue : flipValue}</TextOutput>
+        {/**this second, empty textoutput exists only so that i can simply use 
+         * a single "justify-content: space-between;" on it's wrapper div*/}
+        <TextOutput></TextOutput>
       </div>
     );
   }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -52,7 +52,7 @@ export const Card = (props: CardProps) => {
   }
 
   const handleCancelButtonClick = () => {
-    if (faceValue === "") {
+    if (faceValue === "" && flipValue === "") {
       handleDeleteButtonClick();
     } else {
       handleEditButtonClick();

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Dispatch,
-  MutableRefObject,
-  SetStateAction,
-  useEffect,
-  useState,
-} from "react";
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import styles from "./Card.module.css";
 import { TextInput } from "./TextInput";
 import { SmallIconButton } from "./SmallIconButton";

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,8 +10,8 @@ interface CardProps {
   faceValue?: string;
   /**side B of the card*/
   flipValue?: string;
-  cardsAmount: number;
-  setCardsAmount: Dispatch<SetStateAction<number>>;
+
+  textHeight?: number;
 }
 
 export const Card = (props: CardProps) => {
@@ -41,7 +41,9 @@ export const Card = (props: CardProps) => {
   }, [flipState, faceValue, flipValue]);
 
   //state used for changing the height of the text display
-  const [textOutputHeight, setTextOutputHeight] = useState(19);
+  const [textOutputHeight, setTextOutputHeight] = useState(
+    props.textHeight ? props.textHeight : 19
+  );
 
   //state and custom event for handling card removal
   const [removeStatus, setRemoveStatus] = useState(false);
@@ -70,21 +72,18 @@ export const Card = (props: CardProps) => {
   };
 
   const handleDeleteButtonClick = (event?: React.MouseEvent) => {
-    props.setCardsAmount(props.cardsAmount - 1);
-    setRemoveStatus(true);
-    if (event) event.stopPropagation();
+    setRemoveStatus(true)
   };
 
   const handleTextInputOnChange = function (event: React.ChangeEvent) {
     const target = event.target as HTMLTextAreaElement;
-    const newHeight = target.scrollHeight;
+    const newHeight =
+      target.scrollHeight > textOutputHeight
+        ? target.scrollHeight
+        : textOutputHeight;
     setInputDisplayValue(target.value);
-    target.style.height = `${
-      newHeight > textOutputHeight ? newHeight : textOutputHeight
-    }px`;
-    setTextOutputHeight(
-      newHeight > textOutputHeight ? newHeight : textOutputHeight
-    );
+    target.style.height = `${newHeight}px`;
+    setTextOutputHeight(newHeight);
   };
 
   if (removeStatus) return null;

--- a/src/components/TextInput.module.css
+++ b/src/components/TextInput.module.css
@@ -3,8 +3,8 @@
 .input{
     display: block;
     width: 90%;
-    height: 19px;
-    margin: inherit;
+    height: 39px;
+    padding: 10px;
     border: 1px solid rgba(235, 235, 236, 1);
     resize: none;
     overflow: hidden;

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -5,6 +5,7 @@ interface TextProps extends PropsWithChildren {
   disabled?: boolean;
   onChange?: (event: React.ChangeEvent) => void;
   value?: string;
+  height: number;
 }
 
 export const TextInput = (props: TextProps) => {
@@ -15,6 +16,7 @@ export const TextInput = (props: TextProps) => {
       disabled={props.disabled}
       value={props.value}
       autoFocus={true}
+      style={{ height: props.height+"px" }}
     ></textarea>
   );
 };

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -9,8 +9,6 @@ interface TextProps extends PropsWithChildren {
   value?: string;
 }
 
-
-
 export const TextInput = (props: TextProps) => {
 
   return (
@@ -19,6 +17,7 @@ export const TextInput = (props: TextProps) => {
       onChange={props.onChange}
       disabled={props.disabled}
       value={props.value}
+      autoFocus={true}
     >
     </textarea>
   );

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,6 +1,4 @@
-import React, {
-  PropsWithChildren,
-} from "react";
+import React, { PropsWithChildren } from "react";
 import styles from "./TextInput.module.css";
 
 interface TextProps extends PropsWithChildren {
@@ -10,7 +8,6 @@ interface TextProps extends PropsWithChildren {
 }
 
 export const TextInput = (props: TextProps) => {
-
   return (
     <textarea
       className={styles.input}
@@ -18,7 +15,6 @@ export const TextInput = (props: TextProps) => {
       disabled={props.disabled}
       value={props.value}
       autoFocus={true}
-    >
-    </textarea>
+    ></textarea>
   );
 };

--- a/src/components/TextOutput.tsx
+++ b/src/components/TextOutput.tsx
@@ -3,11 +3,15 @@ import styles from "./TextOutput.module.css";
 
 interface TextOutputProps extends PropsWithChildren {
   className?: string;
+  height: number;
 }
 
 export const TextOutput = (props: TextOutputProps) => {
   return (
-    <div className={props.className ? props.className : styles.output}>
+    <div
+      className={props.className ? props.className : styles.output}
+      style={{ height: props.height+"px" }}
+    >
       {props.children}
     </div>
   );

--- a/src/components/TextOutput.tsx
+++ b/src/components/TextOutput.tsx
@@ -3,7 +3,7 @@ import styles from "./TextOutput.module.css";
 
 interface TextOutputProps extends PropsWithChildren {
   className?: string;
-  height: number;
+  height?: number;
 }
 
 export const TextOutput = (props: TextOutputProps) => {


### PR DESCRIPTION
Now I've implemented removal in such a way, that a card's display simply changes to return null. Functionally it disappears, but it doesn't really get removed from React's point of view. In the screenshot below, you can see that only two cards are being displayed, but the React tree has some additional "empty" cards. Is this solution okay, or should I think of other way to handle card removal? (this would probably require changing the way cards are being displayed in the first place.)


![Screenshot 2023-07-14 at 17 16 01](https://github.com/filwas/fischkapp/assets/69075808/b3f26aea-7a43-40da-b374-0a782acab323)
